### PR TITLE
use static for functions not used outside this compile unit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ buildtype = get_option('buildtype')
 c_args = [
 	'-D_POSIX_C_SOURCE=200809L',
 	'-fvisibility=hidden',
+	'-Wmissing-prototypes',
 ]
 
 if buildtype != 'debug' and buildtype != 'debugoptimized'


### PR DESCRIPTION
Add static for all functions only used inside aml.c. This helps the
compiler to potentially inline these functions. Furthermore the warning
is also used in Weston, and this allows to build aml with the same
compiler flags as Weston is using.