### PR TITLE
Unbreak build on BSDs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ add_project_arguments(c_args, language: 'c')
 
 cc = meson.get_compiler('c')
 
+libepoll = dependency('epoll-shim', required: false)
 librt = cc.find_library('rt', required: true)
 threads = dependency('threads')
 
@@ -36,6 +37,7 @@ sources = [
 ]
 
 dependencies = [
+	libepoll,
 	librt,
 	threads,
 ]


### PR DESCRIPTION
epoll is a Linux feature but BSDs have a shim library over kqueue.
https://github.com/jiixyj/epoll-shim

Alternatively, src/posix.c can be connected with some ifdefs for platforms without epoll or kqueue like Solaris (no clue if it supports Wayland).