### PR TITLE
Allow consumers to link statically

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ dependencies = [
 	threads,
 ]
 
-aml = shared_library(
+aml = library(
 	'aml',
 	sources,
 	version: '0.0.0',


### PR DESCRIPTION
Downstream may pass `-Ddefault_library=static` (or `-Daml:default_library=static`) to avoid packaging dependencies that don't have stable API/ABI.

See also https://mesonbuild.com/Build-targets.html


```
$ git clone https://github.com/any1/wayvnc
$ git clone https://github.com/any1/neatvnc subprojects/neatvnc
$ git clone https://github.com/any1/aml subprojects/aml
$ cd wayvnc
$ meson -Ddefault_library=static _build && meson compile -C _build
$ readelf -d _build/wayvnc | fgrep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libpixman-1.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgbm.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libdrm.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libwayland-client.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libxkbcommon.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libepoll-shim.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libturbojpeg.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgnutls.so.30]
 0x0000000000000001 (NEEDED)             Shared library: [libthr.so.3]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.7]
```
