### PR TITLE
Properly initialize global mutex

### DIFF
--- a/src/aml.c
+++ b/src/aml.c
@@ -154,8 +154,7 @@ struct aml {
 
 static struct aml* aml__default = NULL;
 
-// TODO: Properly initialise this?
-static pthread_mutex_t aml__ref_mutex;
+static pthread_mutex_t aml__ref_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 extern struct aml_backend implementation;
 


### PR DESCRIPTION
Properly initialize the global aml__ref_mutex.

Background: I am experiencing crashes on OSX, when AML objects are deleted, even if they should not yet. 

With this fix, it seems more stable so far.


